### PR TITLE
Modify wrong mapping in preprocess_images

### DIFF
--- a/preprocess_images.py
+++ b/preprocess_images.py
@@ -96,8 +96,6 @@ def get_U2Net_mask(top_path, im_name, device, use_gpu):
     mask[mask > max_val / 2] = 255
     mask = mask.astype(np.uint8)
     mask = resize(mask, (h, w), anti_aliasing=False, order=0)
-    mask[mask < 0.5] = 0
-    mask[mask >= 0.5] = 1
     
     return mask
 


### PR DESCRIPTION
```python
mask = get_U2Net_mask(args.top_path, im_name, device, args.use_gpu)
imageio.imsave(output_path, mask)
```

`mask` needs values of 0 or 255, rather than 0 or 1, otherwise incorrect images will be obtained during visualization.

![image](https://github.com/yael-vinker/SceneSketch/assets/86940141/584cc5fb-cd9c-49ec-b556-7f2634143a6a)
